### PR TITLE
IBX-1694: Rebranded dependency injection container service tags

### DIFF
--- a/src/bundle/Resources/config/services/ezplatform.yaml
+++ b/src/bundle/Resources/config/services/ezplatform.yaml
@@ -10,14 +10,14 @@ services:
         autowire: true
         autoconfigure: false
         tags:
-            - { name: ezplatform.field_type, alias: '%ezcontentquery_identifier%' }
+            - { name: ibexa.field_type, alias: '%ezcontentquery_identifier%' }
         arguments:
             $queryTypeRegistry: '@ezpublish.query_type.registry'
             $identifier: '%ezcontentquery_identifier%'
 
     Ibexa\FieldTypeQuery\FieldType\Mapper\QueryFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.definition, fieldType: '%ezcontentquery_identifier%' }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: '%ezcontentquery_identifier%' }
         arguments:
             $contentTypeService: '@ezpublish.api.service.content_type'
 
@@ -25,16 +25,16 @@ services:
 
     Ibexa\FieldTypeQuery\Persistence\Legacy\Content\FieldValue\Converter\QueryConverter:
         tags:
-            - { name: ezplatform.field_type.legacy_storage.converter, alias: '%ezcontentquery_identifier%' }
+            - { name: ibexa.field_type.storage.legacy.converter, alias: '%ezcontentquery_identifier%' }
 
     ezplatform.query_field_type.not_indexable:
         class: Ibexa\Core\FieldType\Unindexed
         tags:
-            - { name: ezplatform.field_type.indexable, alias: '%ezcontentquery_identifier%' }
+            - { name: ibexa.field_type.indexable, alias: '%ezcontentquery_identifier%' }
 
     Ibexa\FieldTypeQuery\ContentView\FieldDefinitionIdentifierMatcher:
         tags:
-            - { name: ezplatform.view.matcher }
+            - { name: ibexa.view.matcher }
         calls:
             - [setRepository, ['@ezpublish.api.repository']]
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1694](https://issues.ibexa.co/browse/IBX-1694)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#12

In this Pull Request we rename Ibexa's dependency injection container service tags according to the map provided by ibexa/compatibility-layer#12 as a part of the rebranding process. Backward compatibility for old service tags is provided by ibexa/compatibility-layer#12.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Asked for a review
