### PR TITLE
IBX-1696: Rebranded Container parameters and Config Resolver namespaces

### DIFF
--- a/doc/howto/customize_rendering.md
+++ b/doc/howto/customize_rendering.md
@@ -75,7 +75,7 @@ The line view template, used to render each result, can be customized by creatin
 In the example above, gallery images, each image content item will be rendered using the `line` view.  
 THat examples defines a custom template for `image` content items returned by `gallery.images` query field:
 ```yaml
-ezplatform:
+ibexa:
     system:
         default:
             content_view:
@@ -96,6 +96,6 @@ project's config:
 
 ```yaml
 parameters:
-    ezcontentquery_field_view: 'my_content_query_field'
-    ezcontentquery_item_view: 'my_line'
+    ibexa.field_type.query.content.view.field: 'my_content_query_field'
+    ibexa.field_type.query.content.view.item: 'my_line'
 ```  

--- a/src/bundle/DependencyInjection/Compiler/ConfigurableFieldDefinitionMapperPass.php
+++ b/src/bundle/DependencyInjection/Compiler/ConfigurableFieldDefinitionMapperPass.php
@@ -10,12 +10,12 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * Adds the configuration for the query field type to the ezplatform_graphql.schema.content.mapping.field_definition_type
+ * Adds the configuration for the query field type to the ibexa.graphql.schema.content.mapping.field_definition_type
  * configuration variable.
  */
 class ConfigurableFieldDefinitionMapperPass implements CompilerPassInterface
 {
-    public const PARAMETER = 'ezplatform_graphql.schema.content.mapping.field_definition_type';
+    public const PARAMETER = 'ibexa.graphql.schema.content.mapping.field_definition_type';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/bundle/DependencyInjection/Compiler/FieldDefinitionIdentifierViewMatcherPass.php
+++ b/src/bundle/DependencyInjection/Compiler/FieldDefinitionIdentifierViewMatcherPass.php
@@ -23,7 +23,7 @@ class FieldDefinitionIdentifierViewMatcherPass implements CompilerPassInterface
         $configKeys = array_filter(
             array_keys($container->getParameterBag()->all()),
             static function ($parameterName) {
-                return preg_match('/ezsettings\..+\.content_view/', $parameterName);
+                return preg_match('/ibexa.site_access.config\..+\.content_view/', $parameterName);
             }
         );
 

--- a/src/bundle/DependencyInjection/IbexaFieldTypeQueryExtension.php
+++ b/src/bundle/DependencyInjection/IbexaFieldTypeQueryExtension.php
@@ -45,14 +45,14 @@ final class IbexaFieldTypeQueryExtension extends Extension implements PrependExt
      */
     protected function addContentViewConfig(ContainerBuilder $container): void
     {
-        $contentViewDefaults = $container->getParameter('ezsettings.default.content_view_defaults');
+        $contentViewDefaults = $container->getParameter('ibexa.site_access.config.default.content_view_defaults');
         $contentViewDefaults['content_query_field'] = [
             'default' => [
                 'template' => '@IbexaFieldTypeQuery/content/contentquery.html.twig',
                 'match' => [],
             ],
         ];
-        $container->setParameter('ezsettings.default.content_view_defaults', $contentViewDefaults);
+        $container->setParameter('ibexa.site_access.config.default.content_view_defaults', $contentViewDefaults);
     }
 
     protected function prependTwigConfig(ContainerBuilder $container): void
@@ -60,8 +60,8 @@ final class IbexaFieldTypeQueryExtension extends Extension implements PrependExt
         $views = Yaml::parseFile(__DIR__ . '/../Resources/config/default_parameters.yaml')['parameters'];
         $twigGlobals = [
             'ezContentQueryViews' => [
-                'field' => $views['ezcontentquery_field_view'],
-                'item' => $views['ezcontentquery_item_view'],
+                'field' => $views['ibexa.field_type.query.content.view.field'],
+                'item' => $views['ibexa.field_type.query.content.view.item'],
             ],
         ];
         $container->prependExtensionConfig('twig', ['globals' => $twigGlobals]);

--- a/src/bundle/Resources/config/default_parameters.yaml
+++ b/src/bundle/Resources/config/default_parameters.yaml
@@ -1,4 +1,4 @@
 parameters:
-    ezcontentquery_field_view: 'content_query_field'
-    ezcontentquery_item_view: 'line'
-    ezcontentquery_identifier: 'ezcontentquery'
+    ibexa.field_type.query.content.view.field: 'content_query_field'
+    ibexa.field_type.query.content.view.item: 'line'
+    ibexa.field_type.query.content.identifier: 'ezcontentquery'

--- a/src/bundle/Resources/config/services/ezplatform.yaml
+++ b/src/bundle/Resources/config/services/ezplatform.yaml
@@ -10,14 +10,14 @@ services:
         autowire: true
         autoconfigure: false
         tags:
-            - { name: ibexa.field_type, alias: '%ezcontentquery_identifier%' }
+            - { name: ibexa.field_type, alias: '%ibexa.field_type.query.content.identifier%' }
         arguments:
             $queryTypeRegistry: '@Ibexa\Core\QueryType\ArrayQueryTypeRegistry'
-            $identifier: '%ezcontentquery_identifier%'
+            $identifier: '%ibexa.field_type.query.content.identifier%'
 
     Ibexa\FieldTypeQuery\FieldType\Mapper\QueryFormMapper:
         tags:
-            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: '%ezcontentquery_identifier%' }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: '%ibexa.field_type.query.content.identifier%' }
         arguments:
             $contentTypeService: '@ibexa.api.service.content_type'
 
@@ -25,12 +25,12 @@ services:
 
     Ibexa\FieldTypeQuery\Persistence\Legacy\Content\FieldValue\Converter\QueryConverter:
         tags:
-            - { name: ibexa.field_type.storage.legacy.converter, alias: '%ezcontentquery_identifier%' }
+            - { name: ibexa.field_type.storage.legacy.converter, alias: '%ibexa.field_type.query.content.identifier%' }
 
     ibexa.query_field_type.not_indexable:
         class: Ibexa\Core\FieldType\Unindexed
         tags:
-            - { name: ibexa.field_type.indexable, alias: '%ezcontentquery_identifier%' }
+            - { name: ibexa.field_type.indexable, alias: '%ibexa.field_type.query.content.identifier%' }
 
     Ibexa\FieldTypeQuery\ContentView\FieldDefinitionIdentifierMatcher:
         tags:
@@ -40,6 +40,6 @@ services:
 
     Ibexa\FieldTypeQuery\ContentView\QueryResultsInjector:
         arguments:
-            $views: { field: '%ezcontentquery_field_view%', item: '%ezcontentquery_item_view%' }
+            $views: { field: '%ibexa.field_type.query.content.view.field%', item: '%ibexa.field_type.query.content.view.item%' }
         tags:
             - { name: kernel.event_subscriber }

--- a/src/bundle/Resources/config/services/graphql.yaml
+++ b/src/bundle/Resources/config/services/graphql.yaml
@@ -15,4 +15,4 @@ services:
         decorates: Ibexa\Contracts\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper
         arguments:
             $innerMapper: '@Ibexa\FieldTypeQuery\GraphQL\ContentQueryFieldDefinitionMapper.inner'
-            $fieldTypeIdentifier: '%ezcontentquery_identifier%'
+            $fieldTypeIdentifier: '%ibexa.field_type.query.content.identifier%'


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1696](https://issues.ibexa.co/browse/IBX-1696)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#31

Rebranded service container parameter names and Ibexa Config Resolver namespaces to follow unified pattern

### TODO

- [ ] Run regressions
- [ ] Test manually
