### PR TITLE
IBX-1294: Fixed deprecated RequestStack::getMasterRequest usages

### DIFF
--- a/src/lib/ContentView/QueryResultsInjector.php
+++ b/src/lib/ContentView/QueryResultsInjector.php
@@ -105,7 +105,7 @@ final class QueryResultsInjector implements EventSubscriberInterface
         }
 
         if ($paginationLimit !== 0 && $disablePagination !== true) {
-            $request = $this->requestStack->getMasterRequest();
+            $request = $this->requestStack->getMainRequest();
 
             $queryParameters = $view->hasParameter('query') ? $view->getParameter('query') : [];
 


### PR DESCRIPTION
> JIRA: [IBX-1294](https://issues.ibexa.co/browse/IBX-1294)

### Description 

`\Symfony\Component\HttpFoundation\RequestStack::getMasterRequest` method is deprecated  since SF 5.3 and should be replaced by getMainRequest

## Checklist

- [X] Code follows the code style of this project (use `$ composer fix-cs`).
- [ ] Change requires a change to the documentation.
- [X] Code is ready for a review.
