### PR TITLE
Fixed name extraction of the Field Type

### DIFF
--- a/src/bundle/DependencyInjection/IbexaFieldTypeQueryExtension.php
+++ b/src/bundle/DependencyInjection/IbexaFieldTypeQueryExtension.php
@@ -77,7 +77,6 @@ final class IbexaFieldTypeQueryExtension extends Extension implements PrependExt
                     ],
                     'output_dir' => __DIR__ . '/../Resources/translations/',
                     'output_format' => 'xliff',
-                    'extractors' => ['ez_fieldtypes'],
                 ],
             ],
         ]);

--- a/src/lib/FieldType/Query/Type.php
+++ b/src/lib/FieldType/Query/Type.php
@@ -16,8 +16,10 @@ use Ibexa\Core\FieldType\FieldType;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Value as BaseValue;
 use Ibexa\Core\QueryType\QueryTypeRegistry;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 
-final class Type extends FieldType
+final class Type extends FieldType implements TranslationContainerInterface
 {
     protected $validatorConfigurationSchema = [];
 
@@ -236,6 +238,13 @@ final class Type extends FieldType
         }
 
         return $errors;
+    }
+
+    public static function getTranslationMessages(): array
+    {
+        return [
+            Message::create('ezcontentquery.name', 'fieldtypes')->setDesc('Content query'),
+        ];
     }
 }
 


### PR DESCRIPTION
Before this change, all names of Field Types were added to the package. This was because `ez_fieldtypes` was enabled. To avoid similar problems like in the case of the translation of policies all packages use TranslationContainerInterface to add their own names. 