### PR TITLE
IBX-8119: Upgraded minimum PHP version to 8.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,13 +10,13 @@ on:
 jobs:
     cs-fix:
         name: Run code style check
-        runs-on: "ubuntu-20.04"
+        runs-on: "ubuntu-22.04"
         strategy:
             matrix:
                 php:
-                    - '8.0'
+                    - '8.3'
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
 
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
@@ -26,31 +26,26 @@ jobs:
                   extensions: 'pdo_sqlite, gd'
                   tools: cs2pr
 
-            - uses: "ramsey/composer-install@v1"
+            - uses: ramsey/composer-install@v3
               with:
-                  dependency-versions: "highest"
+                  dependency-versions: highest
 
             - name: Run code style check
               run: composer run-script check-cs -- --format=checkstyle | cs2pr
 
     tests:
         name: Unit tests
-        runs-on: "ubuntu-20.04"
+        runs-on: "ubuntu-22.04"
         timeout-minutes: 15
 
         strategy:
             fail-fast: false
             matrix:
                 php:
-                    - '7.4'
-                    - '8.0'
-                composer-options: [ "" ]
-                include:
-                    - php: '8.1'
-                      composer-options: "--ignore-platform-req php"
+                    - '8.3'
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
 
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
@@ -60,10 +55,9 @@ jobs:
                   extensions: pdo_sqlite, gd
                   tools: cs2pr
 
-            - uses: "ramsey/composer-install@v1"
+            - uses: ramsey/composer-install@v3
               with:
-                  dependency-versions: "highest"
-                  composer-options: "${{ matrix.composer-options }}"
+                  dependency-versions: highest
 
             - name: Setup problem matchers for PHPUnit
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/composer.json
+++ b/composer.json
@@ -7,21 +7,21 @@
         "ezsystems/ezplatform-query-fieldtype": "*"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": ">=8.3",
         "ext-json": "*",
-        "ibexa/admin-ui": "~5.0.0@dev",
-        "ibexa/content-forms": "~5.0.0@dev",
-        "ibexa/graphql": "~5.0.0@dev",
-        "ibexa/rest": "~5.0.0@dev",
-        "ibexa/core": "~5.0.0@dev",
+        "ibexa/admin-ui": "~5.0.x-dev",
+        "ibexa/content-forms": "~5.0.x-dev",
+        "ibexa/core": "~5.0.x-dev",
+        "ibexa/graphql": "~5.0.x-dev",
+        "ibexa/rest": "~5.0.x-dev",
+        "psr/log": "^1.1",
         "symfony/dependency-injection": "^5.0",
-        "symfony/expression-language": "^5.0",
         "symfony/event-dispatcher": "^5.0",
+        "symfony/expression-language": "^5.0",
         "symfony/framework-bundle": "^5.0",
         "symfony/http-kernel": "^5.0",
         "symfony/translation": "^5.0",
-        "symfony/yaml": "^5.0",
-        "psr/log": "^1.1"
+        "symfony/yaml": "^5.0"
     },
     "autoload": {
         "psr-4": {
@@ -38,15 +38,15 @@
         }
     },
     "require-dev": {
-        "ibexa/doctrine-schema": "~5.0.0@dev",
-        "ibexa/design-engine": "~5.0.0@dev",
-        "ibexa/fieldtype-richtext": "~5.0.0@dev",
-        "ibexa/search": "~5.0.0@dev",
-        "ibexa/user": "~5.0.0@dev",
-        "ibexa/http-cache": "~5.0.0@dev",
-        "phpspec/phpspec": "^7.1",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "ibexa/code-style": "^1.0",
-        "friendsofphp/php-cs-fixer": "^3.0"
+        "ibexa/design-engine": "~5.0.x-dev",
+        "ibexa/doctrine-schema": "~5.0.x-dev",
+        "ibexa/fieldtype-richtext": "~5.0.x-dev",
+        "ibexa/http-cache": "~5.0.x-dev",
+        "ibexa/search": "~5.0.x-dev",
+        "ibexa/user": "~5.0.x-dev",
+        "phpspec/phpspec": "^7.1"
     },
     "scripts": {
         "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php -v --show-progress=dots",
@@ -61,6 +61,7 @@
     "config": {
         "allow-plugins": {
             "composer/package-versions-deprecated": true
-        }
+        },
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-8119 |
|----------------|-----------|

#### Description:

This PR bumps the minimum required version of PHP to 8.3.
`>=8.3` version constraint is set with expectation of compatibility with version PHP 9.

Additionally, this PR:
 * enforces sorting of packages within `require` and `require-dev` sections of composer.json file
 * replaces `~5.0.0@dev` declarations with their more development friendly `~5.0.x-dev`.
 * adjusts github workflows to match new PHP version
 * updates GH action versions

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!--
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes)
-->
