### PR TITLE
IBX-8139: Dropped class_alias BC layer statements from all classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "psr-4": {
             "Ibexa\\Bundle\\FieldTypeQuery\\": "src/bundle/",
             "Ibexa\\FieldTypeQuery\\": "src/lib/",
-            "Ibexa\\Contracts\\FieldTypeQuery\\": "src/contracts/",
-            "EzSystems\\EzPlatformQueryFieldType\\": "src/lib/"
+            "Ibexa\\Contracts\\FieldTypeQuery\\": "src/contracts/"
         }
     },
     "autoload-dev": {

--- a/src/bundle/Controller/QueryFieldRestController.php
+++ b/src/bundle/Controller/QueryFieldRestController.php
@@ -122,5 +122,3 @@ final class QueryFieldRestController
         return $this->locationService->loadLocation((int)$locationId);
     }
 }
-
-class_alias(QueryFieldRestController::class, 'EzSystems\EzPlatformQueryFieldType\Controller\QueryFieldRestController');

--- a/src/bundle/DependencyInjection/Compiler/ConfigurableFieldDefinitionMapperPass.php
+++ b/src/bundle/DependencyInjection/Compiler/ConfigurableFieldDefinitionMapperPass.php
@@ -33,5 +33,3 @@ class ConfigurableFieldDefinitionMapperPass implements CompilerPassInterface
         $container->setParameter(self::PARAMETER, $parameter);
     }
 }
-
-class_alias(ConfigurableFieldDefinitionMapperPass::class, 'EzSystems\EzPlatformQueryFieldType\Symfony\DependencyInjection\Compiler\ConfigurableFieldDefinitionMapperPass');

--- a/src/bundle/DependencyInjection/Compiler/FieldDefinitionIdentifierViewMatcherPass.php
+++ b/src/bundle/DependencyInjection/Compiler/FieldDefinitionIdentifierViewMatcherPass.php
@@ -43,5 +43,3 @@ class FieldDefinitionIdentifierViewMatcherPass implements CompilerPassInterface
         }
     }
 }
-
-class_alias(FieldDefinitionIdentifierViewMatcherPass::class, 'EzSystems\EzPlatformQueryFieldType\Symfony\DependencyInjection\Compiler\FieldDefinitionIdentifierViewMatcherPass');

--- a/src/bundle/DependencyInjection/Compiler/QueryTypesListPass.php
+++ b/src/bundle/DependencyInjection/Compiler/QueryTypesListPass.php
@@ -60,5 +60,3 @@ class QueryTypesListPass implements CompilerPassInterface
         );
     }
 }
-
-class_alias(QueryTypesListPass::class, 'EzSystems\EzPlatformQueryFieldType\Symfony\DependencyInjection\Compiler\QueryTypesListPass');

--- a/src/bundle/DependencyInjection/IbexaFieldTypeQueryExtension.php
+++ b/src/bundle/DependencyInjection/IbexaFieldTypeQueryExtension.php
@@ -110,5 +110,3 @@ final class IbexaFieldTypeQueryExtension extends Extension implements PrependExt
         ]);
     }
 }
-
-class_alias(IbexaFieldTypeQueryExtension::class, 'EzSystems\EzPlatformQueryFieldType\Symfony\DependencyInjection\EzSystemsEzPlatformQueryFieldTypeExtension');

--- a/src/bundle/IbexaFieldTypeQueryBundle.php
+++ b/src/bundle/IbexaFieldTypeQueryBundle.php
@@ -20,5 +20,3 @@ final class IbexaFieldTypeQueryBundle extends Bundle
         $container->addCompilerPass(new Compiler\FieldDefinitionIdentifierViewMatcherPass());
     }
 }
-
-class_alias(IbexaFieldTypeQueryBundle::class, 'EzSystems\EzPlatformQueryFieldType\Symfony\EzSystemsEzPlatformQueryFieldTypeBundle');

--- a/src/contracts/QueryFieldLocationService.php
+++ b/src/contracts/QueryFieldLocationService.php
@@ -33,5 +33,3 @@ interface QueryFieldLocationService
      */
     public function countContentItemsForLocation(Location $location, string $fieldDefinitionIdentifier): int;
 }
-
-class_alias(QueryFieldLocationService::class, 'EzSystems\EzPlatformQueryFieldType\API\QueryFieldLocationService');

--- a/src/contracts/QueryFieldServiceInterface.php
+++ b/src/contracts/QueryFieldServiceInterface.php
@@ -62,5 +62,3 @@ interface QueryFieldServiceInterface
      */
     public function getPaginationConfiguration(Content $content, string $fieldDefinitionIdentifier): int;
 }
-
-class_alias(QueryFieldServiceInterface::class, 'EzSystems\EzPlatformQueryFieldType\API\QueryFieldServiceInterface');

--- a/src/lib/ContentView/FieldDefinitionIdentifierMatcher.php
+++ b/src/lib/ContentView/FieldDefinitionIdentifierMatcher.php
@@ -83,5 +83,3 @@ final class FieldDefinitionIdentifierMatcher extends MultipleValued
         return in_array($view->getParameter('fieldIdentifier'), $this->getValues(), true);
     }
 }
-
-class_alias(FieldDefinitionIdentifierMatcher::class, 'EzSystems\EzPlatformQueryFieldType\eZ\ContentView\FieldDefinitionIdentifierMatcher');

--- a/src/lib/ContentView/QueryResultsInjector.php
+++ b/src/lib/ContentView/QueryResultsInjector.php
@@ -153,5 +153,3 @@ final class QueryResultsInjector implements EventSubscriberInterface
         }
     }
 }
-
-class_alias(QueryResultsInjector::class, 'EzSystems\EzPlatformQueryFieldType\eZ\ContentView\QueryResultsInjector');

--- a/src/lib/ContentView/QueryResultsPagerFantaAdapter.php
+++ b/src/lib/ContentView/QueryResultsPagerFantaAdapter.php
@@ -50,5 +50,3 @@ final class QueryResultsPagerFantaAdapter implements AdapterInterface
         );
     }
 }
-
-class_alias(QueryResultsPagerFantaAdapter::class, 'EzSystems\EzPlatformQueryFieldType\eZ\ContentView\QueryResultsPagerFantaAdapter');

--- a/src/lib/ContentView/QueryResultsWithLocationPagerFantaAdapter.php
+++ b/src/lib/ContentView/QueryResultsWithLocationPagerFantaAdapter.php
@@ -50,5 +50,3 @@ final class QueryResultsWithLocationPagerFantaAdapter implements AdapterInterfac
         );
     }
 }
-
-class_alias(QueryResultsWithLocationPagerFantaAdapter::class, 'EzSystems\EzPlatformQueryFieldType\eZ\ContentView\QueryResultsWithLocationPagerFantaAdapter');

--- a/src/lib/ExceptionSafeQueryFieldService.php
+++ b/src/lib/ExceptionSafeQueryFieldService.php
@@ -115,5 +115,3 @@ final class ExceptionSafeQueryFieldService implements QueryFieldServiceInterface
         }
     }
 }
-
-class_alias(ExceptionSafeQueryFieldService::class, 'EzSystems\EzPlatformQueryFieldType\API\ExceptionSafeQueryFieldService');

--- a/src/lib/FieldType/Form/QueryFieldFormType.php
+++ b/src/lib/FieldType/Form/QueryFieldFormType.php
@@ -43,5 +43,3 @@ class QueryFieldFormType extends AbstractType
         $builder->addModelTransformer(new FieldValueTransformer($this->fieldTypeService->getFieldType('ezcontentquery')));
     }
 }
-
-class_alias(QueryFieldFormType::class, 'EzSystems\EzPlatformQueryFieldType\eZ\FieldType\Form\QueryFieldFormType');

--- a/src/lib/FieldType/Mapper/ParametersTransformer.php
+++ b/src/lib/FieldType/Mapper/ParametersTransformer.php
@@ -30,5 +30,3 @@ final class ParametersTransformer implements DataTransformerInterface
         return Yaml::parse($value);
     }
 }
-
-class_alias(ParametersTransformer::class, 'EzSystems\EzPlatformQueryFieldType\eZ\FieldType\Mapper\ParametersTransformer');

--- a/src/lib/FieldType/Mapper/QueryFormMapper.php
+++ b/src/lib/FieldType/Mapper/QueryFormMapper.php
@@ -105,5 +105,3 @@ final class QueryFormMapper implements FieldDefinitionFormMapperInterface
         }
     }
 }
-
-class_alias(QueryFormMapper::class, 'EzSystems\EzPlatformQueryFieldType\eZ\FieldType\Mapper\QueryFormMapper');

--- a/src/lib/FieldType/Query/Type.php
+++ b/src/lib/FieldType/Query/Type.php
@@ -248,5 +248,3 @@ final class Type extends FieldType implements TranslationContainerInterface
         ];
     }
 }
-
-class_alias(Type::class, 'EzSystems\EzPlatformQueryFieldType\eZ\FieldType\Query\Type');

--- a/src/lib/FieldType/Query/Value.php
+++ b/src/lib/FieldType/Query/Value.php
@@ -36,5 +36,3 @@ class Value extends BaseValue
         return (string)$this->text;
     }
 }
-
-class_alias(Value::class, 'EzSystems\EzPlatformQueryFieldType\eZ\FieldType\Query\Value');

--- a/src/lib/GraphQL/ContentQueryFieldDefinitionMapper.php
+++ b/src/lib/GraphQL/ContentQueryFieldDefinitionMapper.php
@@ -107,5 +107,3 @@ final class ContentQueryFieldDefinitionMapper extends DecoratingFieldDefinitionM
         );
     }
 }
-
-class_alias(ContentQueryFieldDefinitionMapper::class, 'EzSystems\EzPlatformQueryFieldType\GraphQL\ContentQueryFieldDefinitionMapper');

--- a/src/lib/GraphQL/QueryFieldResolver.php
+++ b/src/lib/GraphQL/QueryFieldResolver.php
@@ -61,5 +61,3 @@ final class QueryFieldResolver
         return $return;
     }
 }
-
-class_alias(QueryFieldResolver::class, 'EzSystems\EzPlatformQueryFieldType\GraphQL\QueryFieldResolver');

--- a/src/lib/Persistence/Legacy/Content/FieldValue/Converter/QueryConverter.php
+++ b/src/lib/Persistence/Legacy/Content/FieldValue/Converter/QueryConverter.php
@@ -99,5 +99,3 @@ class QueryConverter implements Converter
         return 'sort_key_string';
     }
 }
-
-class_alias(QueryConverter::class, 'EzSystems\EzPlatformQueryFieldType\eZ\Persistence\Legacy\Content\FieldValue\Converter\QueryConverter');

--- a/src/lib/QueryFieldPaginationService.php
+++ b/src/lib/QueryFieldPaginationService.php
@@ -15,5 +15,3 @@ namespace Ibexa\FieldTypeQuery;
 interface QueryFieldPaginationService
 {
 }
-
-class_alias(QueryFieldPaginationService::class, 'EzSystems\EzPlatformQueryFieldType\API\QueryFieldPaginationService');

--- a/src/lib/QueryFieldService.php
+++ b/src/lib/QueryFieldService.php
@@ -206,5 +206,3 @@ final class QueryFieldService implements QueryFieldServiceInterface, QueryFieldL
         );
     }
 }
-
-class_alias(QueryFieldService::class, 'EzSystems\EzPlatformQueryFieldType\API\QueryFieldService');


### PR DESCRIPTION
| :ticket: Issue | IBX-8139 |
|----------------|-----------|

#### Description:

Dropped `class_alias` BC layer statements from all classes using https://github.com/ibexa/rector/pull/2

#### For QA:

No QA needed

#### Documentation:

Document that our BC layer has been dropped
