### PR TITLE
IBX-9513: Fixed obsolete ibexa_content Controller reference

### DIFF
--- a/src/bundle/Resources/views/content/contentquery.html.twig
+++ b/src/bundle/Resources/views/content/contentquery.html.twig
@@ -1,6 +1,6 @@
 {% for item in items %}
     {# Should we pass the full item instead ? #}
-    {{ render(controller("ibexa_content:viewAction", {
+    {{ render(controller("ibexa_content::viewAction", {
         "contentId": item.id,
         "content": item,
         "viewType": itemViewType

--- a/src/bundle/Resources/views/fieldtype/field_view.html.twig
+++ b/src/bundle/Resources/views/fieldtype/field_view.html.twig
@@ -2,7 +2,7 @@
 
 {% block ezcontentquery_field %}
 {{ render(controller(
-    "ibexa_content:viewAction",
+    "ibexa_content::viewAction",
     {
         "content": content,
         "location": location ?? null,


### PR DESCRIPTION
| :ticket: Issue | IBX-9513 |
|----------------|----------|

#### Related PRs: 
- https://github.com/ibexa/fieldtype-query/pull/34
- https://github.com/ibexa/fieldtype-richtext/pull/205
- https://github.com/ibexa/core/pull/474
- https://github.com/ibexa/http-cache/pull/56

#### Description:

Single colon notation for controller has been deprecated for some time. Seems we still have some `ibexa_content:viewAction` references.

#### For QA:

As described in JIRA ticket.