### PR TITLE
IBX-9727: Added missing type hints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,9 +48,9 @@
         "ibexa/search": "~5.0.x-dev",
         "ibexa/user": "~5.0.x-dev",
         "phpspec/phpspec": "^7.1",
-        "phpstan/phpstan": "^1.12",
-        "phpstan/phpstan-phpunit": "^1.4",
-        "phpstan/phpstan-symfony": "^1.4"
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-symfony": "^2.0"
     },
     "scripts": {
         "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php -v --show-progress=dots",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,101 +1,115 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#1 \\$locationId of method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\LocationService\\:\\:loadLocation\\(\\) expects int, int\\|null given\\.$#"
+			message: '#^Parameter \#1 \$locationId of method Ibexa\\Contracts\\Core\\Repository\\LocationService\:\:loadLocation\(\) expects int, int\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/bundle/Controller/QueryFieldRestController.php
 
 		-
-			message: "#^Parameter \\#1 \\$uri of method Ibexa\\\\Contracts\\\\Rest\\\\UriParser\\\\UriParserInterface\\:\\:getAttributeFromUri\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$uri of method Ibexa\\Contracts\\Rest\\UriParser\\UriParserInterface\:\:getAttributeFromUri\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/bundle/Controller/QueryFieldRestController.php
 
 		-
-			message: "#^Argument of an invalid type array\\|bool\\|float\\|int\\|string\\|null supplied for foreach, only iterables are supported\\.$#"
+			message: '#^Argument of an invalid type array\|bool\|float\|int\|string\|null supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
 			count: 1
 			path: src/bundle/DependencyInjection/Compiler/FieldDefinitionIdentifierViewMatcherPass.php
 
 		-
-			message: "#^Cannot access offset \\(int\\|string\\) on non\\-empty\\-array\\|bool\\|float\\|int\\|string\\|null\\.$#"
+			message: '#^Cannot access offset \(int\|string\) on non\-empty\-array\|bool\|float\|int\|string\|null\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: src/bundle/DependencyInjection/Compiler/FieldDefinitionIdentifierViewMatcherPass.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(int\\|string\\)\\: bool\\)\\|null, Closure\\(mixed\\)\\: \\(0\\|1\\|false\\) given\\.$#"
+			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(int\|string\)\: bool\)\|null, Closure\(mixed\)\: \(0\|1\|false\) given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/bundle/DependencyInjection/Compiler/FieldDefinitionIdentifierViewMatcherPass.php
 
 		-
-			message: "#^Parameter \\#1 \\$queryTypeIdentifier of method Ibexa\\\\Bundle\\\\FieldTypeQuery\\\\DependencyInjection\\\\Compiler\\\\QueryTypesListPass\\:\\:buildQueryTypeName\\(\\) expects string, int\\|string given\\.$#"
+			message: '#^Parameter \#1 \$queryTypeIdentifier of method Ibexa\\Bundle\\FieldTypeQuery\\DependencyInjection\\Compiler\\QueryTypesListPass\:\:buildQueryTypeName\(\) expects string, int\|string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/bundle/DependencyInjection/Compiler/QueryTypesListPass.php
 
 		-
-			message: "#^Parameter \\#1 \\$input of static method Symfony\\\\Component\\\\Yaml\\\\Yaml\\:\\:parse\\(\\) expects string, string\\|false given\\.$#"
+			message: '#^Parameter \#1 \$input of static method Symfony\\Component\\Yaml\\Yaml\:\:parse\(\) expects string, string\|false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/bundle/DependencyInjection/IbexaFieldTypeQueryExtension.php
 
 		-
-			message: "#^Method Ibexa\\\\FieldTypeQuery\\\\ContentView\\\\QueryResultsInjector\\:\\:__construct\\(\\) has parameter \\$views with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\FieldTypeQuery\\ContentView\\QueryResultsInjector\:\:__construct\(\) has parameter \$views with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/ContentView/QueryResultsInjector.php
 
 		-
-			message: "#^Property Ibexa\\\\FieldTypeQuery\\\\ContentView\\\\QueryResultsInjector\\:\\:\\$queryFieldService \\(Ibexa\\\\Contracts\\\\FieldTypeQuery\\\\QueryFieldLocationService&Ibexa\\\\Contracts\\\\FieldTypeQuery\\\\QueryFieldServiceInterface\\) does not accept Ibexa\\\\Contracts\\\\FieldTypeQuery\\\\QueryFieldServiceInterface\\.$#"
+			message: '#^Property Ibexa\\FieldTypeQuery\\ContentView\\QueryResultsInjector\:\:\$queryFieldService \(Ibexa\\Contracts\\FieldTypeQuery\\QueryFieldLocationService&Ibexa\\Contracts\\FieldTypeQuery\\QueryFieldServiceInterface\) does not accept Ibexa\\Contracts\\FieldTypeQuery\\QueryFieldServiceInterface\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: src/lib/ContentView/QueryResultsInjector.php
 
 		-
-			message: "#^Property Ibexa\\\\FieldTypeQuery\\\\ContentView\\\\QueryResultsInjector\\:\\:\\$views type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Ibexa\\FieldTypeQuery\\ContentView\\QueryResultsInjector\:\:\$views type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/ContentView/QueryResultsInjector.php
 
 		-
-			message: "#^Property Ibexa\\\\FieldTypeQuery\\\\ExceptionSafeQueryFieldService\\:\\:\\$inner \\(Ibexa\\\\Contracts\\\\FieldTypeQuery\\\\QueryFieldLocationService&Ibexa\\\\Contracts\\\\FieldTypeQuery\\\\QueryFieldServiceInterface\\) does not accept Ibexa\\\\Contracts\\\\FieldTypeQuery\\\\QueryFieldServiceInterface\\.$#"
+			message: '#^Property Ibexa\\FieldTypeQuery\\ExceptionSafeQueryFieldService\:\:\$inner \(Ibexa\\Contracts\\FieldTypeQuery\\QueryFieldLocationService&Ibexa\\Contracts\\FieldTypeQuery\\QueryFieldServiceInterface\) does not accept Ibexa\\Contracts\\FieldTypeQuery\\QueryFieldServiceInterface\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: src/lib/ExceptionSafeQueryFieldService.php
 
 		-
-			message: "#^Generator expects key type string, string\\|null given\\.$#"
+			message: '#^Generator expects key type string, string\|null given\.$#'
+			identifier: generator.keyType
 			count: 1
 			path: src/lib/FieldType/Mapper/QueryFormMapper.php
 
 		-
-			message: "#^Property Ibexa\\\\Core\\\\Persistence\\\\Legacy\\\\Content\\\\StorageFieldValue\\:\\:\\$dataText \\(string\\) does not accept array\\|bool\\|float\\|int\\|string\\|null\\.$#"
+			message: '#^Property Ibexa\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue\:\:\$dataText \(string\) does not accept array\|bool\|float\|int\|string\|null\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: src/lib/Persistence/Legacy/Content/FieldValue/Converter/QueryConverter.php
 
 		-
-			message: "#^Method Ibexa\\\\FieldTypeQuery\\\\QueryFieldService\\:\\:isExpression\\(\\) has parameter \\$expression with no type specified\\.$#"
+			message: '#^Method Ibexa\\FieldTypeQuery\\QueryFieldService\:\:isExpression\(\) has parameter \$expression with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/QueryFieldService.php
 
 		-
-			message: "#^Method Ibexa\\\\FieldTypeQuery\\\\QueryFieldService\\:\\:prepareQuery\\(\\) has parameter \\$extraParameters with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\FieldTypeQuery\\QueryFieldService\:\:prepareQuery\(\) has parameter \$extraParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/QueryFieldService.php
 
 		-
-			message: "#^Method Ibexa\\\\FieldTypeQuery\\\\QueryFieldService\\:\\:resolveExpression\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\FieldTypeQuery\\QueryFieldService\:\:resolveExpression\(\) has parameter \$variables with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/QueryFieldService.php
 
 		-
-			message: "#^Method Ibexa\\\\FieldTypeQuery\\\\QueryFieldService\\:\\:resolveExpression\\(\\) has parameter \\$variables with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\FieldTypeQuery\\QueryFieldService\:\:resolveParameters\(\) has parameter \$expressions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/QueryFieldService.php
 
 		-
-			message: "#^Method Ibexa\\\\FieldTypeQuery\\\\QueryFieldService\\:\\:resolveParameters\\(\\) has parameter \\$expressions with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\FieldTypeQuery\\QueryFieldService\:\:resolveParameters\(\) has parameter \$variables with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/QueryFieldService.php
 
 		-
-			message: "#^Method Ibexa\\\\FieldTypeQuery\\\\QueryFieldService\\:\\:resolveParameters\\(\\) has parameter \\$variables with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/QueryFieldService.php
-
-		-
-			message: "#^Method Ibexa\\\\FieldTypeQuery\\\\QueryFieldService\\:\\:resolveParameters\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\FieldTypeQuery\\QueryFieldService\:\:resolveParameters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/QueryFieldService.php

--- a/spec/ContentView/FieldDefinitionIdentifierMatcherSpec.php
+++ b/spec/ContentView/FieldDefinitionIdentifierMatcherSpec.php
@@ -30,7 +30,7 @@ class FieldDefinitionIdentifierMatcherSpec extends ObjectBehavior
 
     public const FIELD_DEFINITION_IDENTIFIER = 'field_definition';
 
-    public function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(FieldDefinitionIdentifierMatcher::class);
         $this->shouldHaveType(ViewMatcherInterface::class);
@@ -45,7 +45,7 @@ class FieldDefinitionIdentifierMatcherSpec extends ObjectBehavior
         return  $matcher;
     }
 
-    public function let(Repository $repository, ContentTypeService $contentTypeService)
+    public function let(Repository $repository, ContentTypeService $contentTypeService): void
     {
         $repository->getContentTypeService()->willReturn($contentTypeService);
         $contentTypeService->loadContentType(self::CONTENT_TYPE_ID_WITHOUT_FIELD_DEFINITION)->willReturn($this->createContentTypeWithoutFieldDefinition());
@@ -53,19 +53,19 @@ class FieldDefinitionIdentifierMatcherSpec extends ObjectBehavior
         $this->beConstructedThrough([$this, 'initialize'], [$repository, [self::FIELD_DEFINITION_IDENTIFIER]]);
     }
 
-    public function it_does_not_match_if_field_definition_identifier_does_not_exist()
+    public function it_does_not_match_if_field_definition_identifier_does_not_exist(): void
     {
         $view = $this->buildView(self::CONTENT_TYPE_ID_WITHOUT_FIELD_DEFINITION);
         $this->match($view)->shouldBe(false);
     }
 
-    public function it_matches_if_field_definition_identifier_matches()
+    public function it_matches_if_field_definition_identifier_matches(): void
     {
         $view = $this->buildView(self::CONTENT_TYPE_ID_WITH_FIELD_DEFINITION);
         $this->match($view)->shouldBe(true);
     }
 
-    private function buildView($contentTypeId): ContentView
+    private function buildView(int $contentTypeId): ContentView
     {
         $view = new ContentView();
         $view->setContent(

--- a/spec/ContentView/QueryResultsInjectorSpec.php
+++ b/spec/ContentView/QueryResultsInjectorSpec.php
@@ -28,11 +28,9 @@ class QueryResultsInjectorSpec extends ObjectBehavior
     public const VIEWS = ['field' => self::FIELD_VIEW, 'item' => self::ITEM_VIEW];
     public const FIELD_DEFINITION_IDENTIFIER = 'query_field';
 
-    /** @var \Ibexa\Core\MVC\Symfony\View\ContentView */
-    private $view;
+    private ContentView $view;
 
-    /** @var \Ibexa\Core\MVC\Symfony\View\Event\FilterViewParametersEvent */
-    private $event;
+    private FilterViewParametersEvent $event;
 
     public function __construct()
     {
@@ -52,7 +50,7 @@ class QueryResultsInjectorSpec extends ObjectBehavior
         );
     }
 
-    public function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(QueryResultsInjector::class);
     }
@@ -61,7 +59,7 @@ class QueryResultsInjectorSpec extends ObjectBehavior
         QueryFieldServiceInterface $queryFieldService,
         FilterViewParametersEvent $event,
         RequestStack $requestStack
-    ) {
+    ): void {
         $this->beConstructedWith($queryFieldService, self::VIEWS, $requestStack);
         $event->getView()->willReturn($this->view);
         $event->getBuilderParameters()->willReturn(
@@ -76,7 +74,7 @@ class QueryResultsInjectorSpec extends ObjectBehavior
     public function it_throws_an_InvalidArgumentException_if_no_item_view_is_provided(
         QueryFieldServiceInterface $queryFieldService,
         RequestStack $requestStack
-    ) {
+    ): void {
         $this->beConstructedWith($queryFieldService, ['field' => self::FIELD_VIEW], $requestStack);
         $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
     }
@@ -84,29 +82,29 @@ class QueryResultsInjectorSpec extends ObjectBehavior
     public function it_throws_an_InvalidArgumentException_if_no_field_view_is_provided(
         QueryFieldServiceInterface $queryFieldService,
         RequestStack $requestStack
-    ) {
+    ): void {
         $this->beConstructedWith($queryFieldService, ['item' => 'field'], $requestStack);
         $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
     }
 
-    public function it_is_an_event_subscriber()
+    public function it_is_an_event_subscriber(): void
     {
         $this->shouldHaveType(EventSubscriberInterface::class);
     }
 
-    public function it_subscribes_to_the_FILTER_VIEW_PARAMETERS_View_Event()
+    public function it_subscribes_to_the_FILTER_VIEW_PARAMETERS_View_Event(): void
     {
         $this->getSubscribedEvents()->shouldSubscribeTo(ViewEvents::FILTER_VIEW_PARAMETERS);
     }
 
-    public function it_does_nothing_for_non_field_views(QueryFieldServiceInterface $queryFieldService)
+    public function it_does_nothing_for_non_field_views(QueryFieldServiceInterface $queryFieldService): void
     {
         $this->event->getView()->setViewType(self::OTHER_VIEW);
         $this->injectQueryResults($this->event);
         $queryFieldService->getPaginationConfiguration(Argument::any())->shouldNotHaveBeenCalled();
     }
 
-    public function it_adds_the_query_results_for_the_field_view_without_pagination(QueryFieldServiceInterface $queryFieldService)
+    public function it_adds_the_query_results_for_the_field_view_without_pagination(QueryFieldServiceInterface $queryFieldService): void
     {
         $content = $this->createContentItem();
 
@@ -133,7 +131,7 @@ class QueryResultsInjectorSpec extends ObjectBehavior
     public function it_adds_the_query_results_for_the_field_view_with_pagination(
         FilterViewParametersEvent $event,
         QueryFieldServiceInterface $queryFieldService
-    ) {
+    ): void {
         $content = $this->createContentItem();
 
         $queryFieldService
@@ -161,7 +159,7 @@ class QueryResultsInjectorSpec extends ObjectBehavior
     public function getMatchers(): array
     {
         return [
-            'subscribeTo' => static function ($return, $event) {
+            'subscribeTo' => static function ($return, $event): bool {
                 return is_array($return) && isset($return[$event]);
             },
         ];

--- a/spec/ExceptionSafeQueryFieldServiceSpec.php
+++ b/spec/ExceptionSafeQueryFieldServiceSpec.php
@@ -15,7 +15,7 @@ use Prophecy\Argument;
 
 class ExceptionSafeQueryFieldServiceSpec extends ObjectBehavior
 {
-    public function let(QueryFieldServiceInterface $queryFieldService)
+    public function let(QueryFieldServiceInterface $queryFieldService): void
     {
         $arguments = [
             Argument::type(Content::class),
@@ -31,24 +31,24 @@ class ExceptionSafeQueryFieldServiceSpec extends ObjectBehavior
         $this->beConstructedWith($queryFieldService);
     }
 
-    public function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(ExceptionSafeQueryFieldService::class);
     }
 
-    public function it_should_return_empty_results_on_count_content_items()
+    public function it_should_return_empty_results_on_count_content_items(): void
     {
         $result = $this->countContentItems(new Content([]), 'any');
         $result->shouldBe(0);
     }
 
-    public function it_should_return_empty_results_on_load_content_items()
+    public function it_should_return_empty_results_on_load_content_items(): void
     {
         $result = $this->loadContentItems(new Content([]), 'any');
         $result->shouldBe([]);
     }
 
-    public function it_should_return_empty_results_on_load_content_items_slice()
+    public function it_should_return_empty_results_on_load_content_items_slice(): void
     {
         $result = $this->loadContentItemsSlice(new Content([]), 'any', 0, 5);
         $result->shouldBe([]);

--- a/spec/GraphQL/ContentQueryFieldDefinitionMapperSpec.php
+++ b/spec/GraphQL/ContentQueryFieldDefinitionMapperSpec.php
@@ -26,7 +26,7 @@ class ContentQueryFieldDefinitionMapperSpec extends ObjectBehavior
         FieldDefinitionMapper $innerMapper,
         NameHelper $nameHelper,
         ContentTypeService $contentTypeService
-    ) {
+    ): void {
         $contentType = new ContentType(['identifier' => self::RETURNED_CONTENT_TYPE_IDENTIFIER]);
 
         $contentTypeService
@@ -40,13 +40,13 @@ class ContentQueryFieldDefinitionMapperSpec extends ObjectBehavior
         $this->beConstructedWith($innerMapper, $nameHelper, $contentTypeService, self::FIELD_TYPE_IDENTIFIER);
     }
 
-    public function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(ContentQueryFieldDefinitionMapper::class);
         $this->shouldHaveType(FieldDefinitionMapper::class);
     }
 
-    public function it_returns_as_value_type_the_configured_ContentType_for_query_field_definitions(FieldDefinitionMapper $innerMapper)
+    public function it_returns_as_value_type_the_configured_ContentType_for_query_field_definitions(FieldDefinitionMapper $innerMapper): void
     {
         $fieldDefinition = $this->fieldDefinition();
         $innerMapper->mapToFieldValueType($fieldDefinition)->shouldNotBeCalled();
@@ -55,7 +55,7 @@ class ContentQueryFieldDefinitionMapperSpec extends ObjectBehavior
             ->shouldBe('[' . self::GRAPHQL_TYPE . ']');
     }
 
-    public function it_delegates_value_type_to_the_inner_mapper_for_a_non_query_field_definition(FieldDefinitionMapper $innerMapper)
+    public function it_delegates_value_type_to_the_inner_mapper_for_a_non_query_field_definition(FieldDefinitionMapper $innerMapper): void
     {
         $fieldDefinition = $this->getLambdaFieldDefinition();
         $innerMapper->mapToFieldValueType($fieldDefinition)->willReturn('SomeType');
@@ -64,7 +64,7 @@ class ContentQueryFieldDefinitionMapperSpec extends ObjectBehavior
             ->shouldBe('SomeType');
     }
 
-    public function it_returns_the_correct_field_definition_GraphQL_type(FieldDefinitionMapper $innerMapper)
+    public function it_returns_the_correct_field_definition_GraphQL_type(FieldDefinitionMapper $innerMapper): void
     {
         $fieldDefinition = $this->fieldDefinition();
         $innerMapper->mapToFieldDefinitionType($fieldDefinition)->shouldNotBeCalled();
@@ -73,7 +73,7 @@ class ContentQueryFieldDefinitionMapperSpec extends ObjectBehavior
             ->shouldBe('ContentQueryFieldDefinition');
     }
 
-    public function it_delegates_field_definition_type_to_the_parent_mapper_for_a_non_query_field_definition(FieldDefinitionMapper $innerMapper)
+    public function it_delegates_field_definition_type_to_the_parent_mapper_for_a_non_query_field_definition(FieldDefinitionMapper $innerMapper): void
     {
         $fieldDefinition = $this->getLambdaFieldDefinition();
         $innerMapper->mapToFieldDefinitionType($fieldDefinition)->willReturn('FieldValue');
@@ -82,7 +82,7 @@ class ContentQueryFieldDefinitionMapperSpec extends ObjectBehavior
             ->shouldBe('FieldValue');
     }
 
-    public function it_maps_the_field_value_when_pagination_is_disabled(FieldDefinitionMapper $innerMapper)
+    public function it_maps_the_field_value_when_pagination_is_disabled(FieldDefinitionMapper $innerMapper): void
     {
         $fieldDefinition = $this->fieldDefinition();
         $innerMapper->mapToFieldValueResolver($fieldDefinition)->shouldNotBeCalled();
@@ -91,7 +91,7 @@ class ContentQueryFieldDefinitionMapperSpec extends ObjectBehavior
             ->shouldBe('@=resolver("QueryFieldValue", [field, content])');
     }
 
-    public function it_maps_the_field_value_when_pagination_is_enabled(FieldDefinitionMapper $innerMapper)
+    public function it_maps_the_field_value_when_pagination_is_enabled(FieldDefinitionMapper $innerMapper): void
     {
         $fieldDefinition = $this->fieldDefinition(true);
         $innerMapper->mapToFieldValueResolver($fieldDefinition)->shouldNotBeCalled();
@@ -120,7 +120,7 @@ class ContentQueryFieldDefinitionMapperSpec extends ObjectBehavior
     /**
      * @return \Ibexa\Core\Repository\Values\ContentType\FieldDefinition
      */
-    protected function getLambdaFieldDefinition(): \Ibexa\Core\Repository\Values\ContentType\FieldDefinition
+    protected function getLambdaFieldDefinition(): FieldDefinition
     {
         return new FieldDefinition(['fieldTypeIdentifier' => 'lambda']);
     }

--- a/spec/GraphQL/QueryFieldResolverSpec.php
+++ b/spec/GraphQL/QueryFieldResolverSpec.php
@@ -17,17 +17,17 @@ class QueryFieldResolverSpec extends ObjectBehavior
 {
     public const FIELD_DEFINITION_IDENTIFIER = 'test';
 
-    public function let(QueryFieldServiceInterface $queryFieldService)
+    public function let(QueryFieldServiceInterface $queryFieldService): void
     {
         $this->beConstructedWith($queryFieldService);
     }
 
-    public function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(QueryFieldResolver::class);
     }
 
-    public function it_resolves_a_query_field(QueryFieldServiceInterface $queryFieldService)
+    public function it_resolves_a_query_field(QueryFieldServiceInterface $queryFieldService): void
     {
         $content = new Content();
         $field = new Field(['fieldDefIdentifier' => self::FIELD_DEFINITION_IDENTIFIER, 'value' => new \stdClass()]);

--- a/spec/Persistence/Legacy/Content/FieldValue/Converter/QueryConverterSpec.php
+++ b/spec/Persistence/Legacy/Content/FieldValue/Converter/QueryConverterSpec.php
@@ -21,7 +21,7 @@ class QueryConverterSpec extends ObjectBehavior
     public const ENABLE_PAGINATION = true;
     public const ITEMS_PER_PAGE = 10;
 
-    public function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(QueryConverter::class);
     }
@@ -52,70 +52,70 @@ class QueryConverterSpec extends ObjectBehavior
         return $fieldDefinition;
     }
 
-    public function it_stores_Parameters_in_dataText5_in_json_format()
+    public function it_stores_Parameters_in_dataText5_in_json_format(): void
     {
         $storageFieldDefinition = new StorageFieldDefinition();
         $this->toStorageFieldDefinition($this->getFieldDefinition(), $storageFieldDefinition);
         Assert::eq($storageFieldDefinition->dataText5, \json_encode(self::PARAMETERS));
     }
 
-    public function it_stores_QueryType_in_dataText1()
+    public function it_stores_QueryType_in_dataText1(): void
     {
         $storageFieldDefinition = new StorageFieldDefinition();
         $this->toStorageFieldDefinition($this->getFieldDefinition(), $storageFieldDefinition);
         Assert::eq($storageFieldDefinition->dataText1, self::QUERY_TYPE);
     }
 
-    public function it_stores_ReturnedType_in_dataText2()
+    public function it_stores_ReturnedType_in_dataText2(): void
     {
         $storageFieldDefinition = new StorageFieldDefinition();
         $this->toStorageFieldDefinition($this->getFieldDefinition(), $storageFieldDefinition);
         Assert::eq($storageFieldDefinition->dataText2, self::RETURNED_TYPE);
     }
 
-    public function it_stores_EnablePagination_in_dataInt1()
+    public function it_stores_EnablePagination_in_dataInt1(): void
     {
         $storageFieldDefinition = new StorageFieldDefinition();
         $this->toStorageFieldDefinition($this->getFieldDefinition(), $storageFieldDefinition);
         Assert::eq($storageFieldDefinition->dataInt1, self::ENABLE_PAGINATION);
     }
 
-    public function it_stores_ItemsPerPage_in_dataInt2()
+    public function it_stores_ItemsPerPage_in_dataInt2(): void
     {
         $storageFieldDefinition = new StorageFieldDefinition();
         $this->toStorageFieldDefinition($this->getFieldDefinition(), $storageFieldDefinition);
         Assert::eq($storageFieldDefinition->dataInt2, self::ITEMS_PER_PAGE);
     }
 
-    public function it_reads_Parameters_from_dataText5_in_json_format()
+    public function it_reads_Parameters_from_dataText5_in_json_format(): void
     {
         $storageFieldDefinition = new StorageFieldDefinition();
         $this->toStorageFieldDefinition($this->getFieldDefinition(), $storageFieldDefinition);
         Assert::eq($storageFieldDefinition->dataText5, \json_encode(self::PARAMETERS));
     }
 
-    public function it_reads_QueryType_from_dataText1()
+    public function it_reads_QueryType_from_dataText1(): void
     {
         $storageFieldDefinition = new StorageFieldDefinition();
         $this->toStorageFieldDefinition($this->getFieldDefinition(), $storageFieldDefinition);
         Assert::eq($storageFieldDefinition->dataText1, self::QUERY_TYPE);
     }
 
-    public function it_reads_ReturnedType_from_dataText2()
+    public function it_reads_ReturnedType_from_dataText2(): void
     {
         $storageFieldDefinition = new StorageFieldDefinition();
         $this->toStorageFieldDefinition($this->getFieldDefinition(), $storageFieldDefinition);
         Assert::eq($storageFieldDefinition->dataText2, self::RETURNED_TYPE);
     }
 
-    public function it_reads_EnablePagination_from_dataInt1()
+    public function it_reads_EnablePagination_from_dataInt1(): void
     {
         $storageFieldDefinition = new StorageFieldDefinition();
         $this->toStorageFieldDefinition($this->getFieldDefinition(), $storageFieldDefinition);
         Assert::eq($storageFieldDefinition->dataInt1, self::ENABLE_PAGINATION);
     }
 
-    public function it_reads_ItemsPerPage_from_dataInt2()
+    public function it_reads_ItemsPerPage_from_dataInt2(): void
     {
         $storageFieldDefinition = new StorageFieldDefinition();
         $this->toStorageFieldDefinition($this->getFieldDefinition(), $storageFieldDefinition);

--- a/spec/QueryFieldServiceSpec.php
+++ b/spec/QueryFieldServiceSpec.php
@@ -29,18 +29,18 @@ class QueryFieldServiceSpec extends ObjectBehavior
     public const QUERY_TYPE_IDENTIFIER = 'query_type_identifier';
     public const FIELD_DEFINITION_IDENTIFIER = 'test';
 
-    private $searchResult;
+    private ?SearchResult $searchResult = null;
 
-    private $searchHits;
+    private ?array $searchHits = null;
 
-    private $totalCount = 0;
+    private int $totalCount = 0;
 
     public function let(
         SearchService $searchService,
         ContentTypeService $contentTypeService,
         QueryTypeRegistry $queryTypeRegistry,
         QueryType $queryType
-    ) {
+    ): void {
         $this->searchHits = [];
         $this->searchResult = new SearchResult(['searchHits' => $this->searchHits, 'totalCount' => $this->totalCount]);
 
@@ -62,22 +62,22 @@ class QueryFieldServiceSpec extends ObjectBehavior
         $this->beConstructedWith($searchService, $contentTypeService, $queryTypeRegistry);
     }
 
-    public function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(QueryFieldService::class);
     }
 
-    public function it_loads_items_from_a_query_field_for_a_given_content_item()
+    public function it_loads_items_from_a_query_field_for_a_given_content_item(): void
     {
         $this->loadContentItems($this->getContent(), self::FIELD_DEFINITION_IDENTIFIER)->shouldBe($this->searchHits);
     }
 
-    public function it_counts_items_from_a_query_field_for_a_given_content_item()
+    public function it_counts_items_from_a_query_field_for_a_given_content_item(): void
     {
         $this->countContentItems($this->getContent(), self::FIELD_DEFINITION_IDENTIFIER)->shouldBe($this->totalCount);
     }
 
-    public function it_deducts_any_offset_when_counting_results(QueryType $queryType, SearchService $searchService)
+    public function it_deducts_any_offset_when_counting_results(QueryType $queryType, SearchService $searchService): void
     {
         $query = new ApiContentQuery();
         $query->offset = 5;
@@ -90,7 +90,7 @@ class QueryFieldServiceSpec extends ObjectBehavior
         $this->countContentItems($this->getContent(), self::FIELD_DEFINITION_IDENTIFIER)->shouldBe(2);
     }
 
-    public function it_returns_zero_if_offset_is_bigger_than_count(QueryType $queryType, SearchService $searchService)
+    public function it_returns_zero_if_offset_is_bigger_than_count(QueryType $queryType, SearchService $searchService): void
     {
         $query = new ApiContentQuery();
         $query->offset = 8;
@@ -103,7 +103,7 @@ class QueryFieldServiceSpec extends ObjectBehavior
         $this->countContentItems($this->getContent(), self::FIELD_DEFINITION_IDENTIFIER)->shouldBe(0);
     }
 
-    public function it_returns_0_as_pagination_configuration_if_pagination_is_disabled()
+    public function it_returns_0_as_pagination_configuration_if_pagination_is_disabled(): void
     {
         $this->getPaginationConfiguration(
             $this->getContent(self::CONTENT_TYPE_ID_WITHOUT_PAGINATION),
@@ -111,7 +111,7 @@ class QueryFieldServiceSpec extends ObjectBehavior
         )->shouldBe(0);
     }
 
-    public function it_returns_the_items_per_page_number_as_pagination_configuration_if_pagination_is_enabled()
+    public function it_returns_the_items_per_page_number_as_pagination_configuration_if_pagination_is_enabled(): void
     {
         $this->getPaginationConfiguration(
             $this->getContent(),
@@ -142,7 +142,7 @@ class QueryFieldServiceSpec extends ObjectBehavior
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType
      */
-    private function getContentType(array $parameters, bool $enablePagination = true, $itemsPerPage = 10): ContentType
+    private function getContentType(array $parameters, bool $enablePagination = true, int $itemsPerPage = 10): ContentType
     {
         $contentType = new Values\ContentType\ContentType([
             'fieldDefinitions' => new Values\ContentType\FieldDefinitionCollection([

--- a/src/bundle/Controller/QueryFieldRestController.php
+++ b/src/bundle/Controller/QueryFieldRestController.php
@@ -78,9 +78,8 @@ final class QueryFieldRestController
                 $items = $this->queryFieldService->loadContentItemsSliceForLocation($location, $fieldDefinitionIdentifier, $offset, $limit);
             }
         } else {
-            $location = null;
             $content = $this->contentService->loadContent($contentId, null, $versionNumber);
-            if ($limit === -1 || !method_exists($this->queryFieldService, 'loadContentItemsSlice')) {
+            if ($limit === -1) {
                 $items = $this->queryFieldService->loadContentItems($content, $fieldDefinitionIdentifier);
             } else {
                 $items = $this->queryFieldService->loadContentItemsSlice($content, $fieldDefinitionIdentifier, $offset, $limit);

--- a/src/bundle/Controller/QueryFieldRestController.php
+++ b/src/bundle/Controller/QueryFieldRestController.php
@@ -19,21 +19,18 @@ use Ibexa\Contracts\Rest\UriParser\UriParserInterface;
 use Ibexa\FieldTypeQuery\QueryFieldService;
 use function Ibexa\PolyfillPhp82\iterator_to_array;
 use Ibexa\Rest\Server\Values as RestValues;
+use Ibexa\Rest\Server\Values\RestContent;
 use Symfony\Component\HttpFoundation\Request;
 
 final class QueryFieldRestController
 {
-    /** @var \Ibexa\FieldTypeQuery\QueryFieldService */
-    private $queryFieldService;
+    private QueryFieldService $queryFieldService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\ContentService */
-    private $contentService;
+    private ContentService $contentService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\LocationService */
-    private $locationService;
+    private LocationService $locationService;
 
     private UriParserInterface $uriParser;
 
@@ -92,8 +89,8 @@ final class QueryFieldRestController
 
         return new RestValues\ContentList(
             array_map(
-                function (Content $content) {
-                    return new RestValues\RestContent(
+                function (Content $content): RestContent {
+                    return new RestContent(
                         $content->contentInfo,
                         $this->locationService->loadLocation($content->contentInfo->mainLocationId),
                         $content,

--- a/src/bundle/DependencyInjection/Compiler/FieldDefinitionIdentifierViewMatcherPass.php
+++ b/src/bundle/DependencyInjection/Compiler/FieldDefinitionIdentifierViewMatcherPass.php
@@ -23,7 +23,7 @@ class FieldDefinitionIdentifierViewMatcherPass implements CompilerPassInterface
     {
         $configKeys = array_filter(
             array_keys($container->getParameterBag()->all()),
-            static function ($parameterName) {
+            static function ($parameterName): int|false {
                 return preg_match('/ibexa.site_access.config\..+\.content_view/', $parameterName);
             }
         );

--- a/src/bundle/DependencyInjection/Compiler/QueryTypesListPass.php
+++ b/src/bundle/DependencyInjection/Compiler/QueryTypesListPass.php
@@ -15,10 +15,7 @@ use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter
 
 class QueryTypesListPass implements CompilerPassInterface
 {
-    /**
-     * @var \Symfony\Component\Serializer\NameConverter\NameConverterInterface
-     */
-    private $nameConverter;
+    private CamelCaseToSnakeCaseNameConverter $nameConverter;
 
     public function __construct()
     {

--- a/src/lib/ContentView/QueryResultsInjector.php
+++ b/src/lib/ContentView/QueryResultsInjector.php
@@ -21,13 +21,11 @@ use Symfony\Component\HttpFoundation\RequestStack;
 final class QueryResultsInjector implements EventSubscriberInterface
 {
     /** @var \Ibexa\Contracts\FieldTypeQuery\QueryFieldServiceInterface&\Ibexa\Contracts\FieldTypeQuery\QueryFieldLocationService */
-    private $queryFieldService;
+    private QueryFieldServiceInterface $queryFieldService;
 
-    /** @var array */
-    private $views;
+    private array $views;
 
-    /** @var \Symfony\Component\HttpFoundation\RequestStack */
-    private $requestStack;
+    private RequestStack $requestStack;
 
     public function __construct(QueryFieldServiceInterface $queryFieldService, array $views, RequestStack $requestStack)
     {

--- a/src/lib/ContentView/QueryResultsInjector.php
+++ b/src/lib/ContentView/QueryResultsInjector.php
@@ -102,7 +102,7 @@ final class QueryResultsInjector implements EventSubscriberInterface
             $paginationLimit = $viewParameters['itemsPerPage'];
         }
 
-        if (($enablePagination === true) && (!is_numeric($paginationLimit) || $paginationLimit === 0)) {
+        if (($enablePagination === true) && (!$paginationLimit || $paginationLimit <= 0)) {
             throw new \InvalidArgumentException("The 'itemsPerPage' parameter must be given with a positive integer value if 'enablePagination' is set");
         }
 

--- a/src/lib/ContentView/QueryResultsPagerFantaAdapter.php
+++ b/src/lib/ContentView/QueryResultsPagerFantaAdapter.php
@@ -16,14 +16,11 @@ use Pagerfanta\Adapter\AdapterInterface;
  */
 final class QueryResultsPagerFantaAdapter implements AdapterInterface
 {
-    /** @var \Ibexa\Contracts\FieldTypeQuery\QueryFieldServiceInterface */
-    private $queryFieldService;
+    private QueryFieldServiceInterface $queryFieldService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Content */
-    private $content;
+    private Content $content;
 
-    /** @var string */
-    private $fieldDefinitionIdentifier;
+    private string $fieldDefinitionIdentifier;
 
     public function __construct(
         QueryFieldServiceInterface $queryFieldService,

--- a/src/lib/ContentView/QueryResultsWithLocationPagerFantaAdapter.php
+++ b/src/lib/ContentView/QueryResultsWithLocationPagerFantaAdapter.php
@@ -16,14 +16,11 @@ use Pagerfanta\Adapter\AdapterInterface;
  */
 final class QueryResultsWithLocationPagerFantaAdapter implements AdapterInterface
 {
-    /** @var \Ibexa\Contracts\FieldTypeQuery\QueryFieldLocationService */
-    private $queryFieldService;
+    private QueryFieldLocationService $queryFieldService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Location */
-    private $location;
+    private Location $location;
 
-    /** @var string */
-    private $fieldDefinitionIdentifier;
+    private string $fieldDefinitionIdentifier;
 
     public function __construct(
         QueryFieldLocationService $queryFieldService,

--- a/src/lib/ExceptionSafeQueryFieldService.php
+++ b/src/lib/ExceptionSafeQueryFieldService.php
@@ -24,7 +24,7 @@ final class ExceptionSafeQueryFieldService implements QueryFieldServiceInterface
     use LoggerAwareTrait;
 
     /** @var \Ibexa\Contracts\FieldTypeQuery\QueryFieldServiceInterface&\Ibexa\Contracts\FieldTypeQuery\QueryFieldLocationService */
-    private $inner;
+    private QueryFieldServiceInterface $inner;
 
     public function __construct(QueryFieldServiceInterface $inner, ?LoggerInterface $logger = null)
     {

--- a/src/lib/FieldType/Form/QueryFieldFormType.php
+++ b/src/lib/FieldType/Form/QueryFieldFormType.php
@@ -15,8 +15,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class QueryFieldFormType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\Repository\FieldTypeService */
-    private $fieldTypeService;
+    private FieldTypeService $fieldTypeService;
 
     public function __construct(FieldTypeService $fieldTypeService)
     {

--- a/src/lib/FieldType/Form/QueryFieldFormType.php
+++ b/src/lib/FieldType/Form/QueryFieldFormType.php
@@ -13,6 +13,9 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
+/**
+ * @phpstan-extends \Symfony\Component\Form\AbstractType<string>
+ */
 class QueryFieldFormType extends AbstractType
 {
     private FieldTypeService $fieldTypeService;

--- a/src/lib/FieldType/Mapper/QueryFormMapper.php
+++ b/src/lib/FieldType/Mapper/QueryFormMapper.php
@@ -16,15 +16,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class QueryFormMapper implements FieldDefinitionFormMapperInterface
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
     /**
      * List of query types.
      *
      * @var array<int|string, string>
      */
-    private $queryTypes;
+    private array $queryTypes;
 
     /**
      * @param array<int|string, string> $queryTypes

--- a/src/lib/FieldType/Mapper/QueryFormMapper.php
+++ b/src/lib/FieldType/Mapper/QueryFormMapper.php
@@ -34,6 +34,9 @@ final class QueryFormMapper implements FieldDefinitionFormMapperInterface
         $this->queryTypes = $queryTypes;
     }
 
+    /**
+     * @param \Symfony\Component\Form\FormInterface<mixed> $fieldDefinitionForm
+     */
     public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data): void
     {
         $parametersForm = $fieldDefinitionForm->getConfig()->getFormFactory()->createBuilder()

--- a/src/lib/FieldType/Query/Type.php
+++ b/src/lib/FieldType/Query/Type.php
@@ -32,14 +32,11 @@ final class Type extends FieldType implements TranslationContainerInterface
         'ItemsPerPage' => ['type' => 'integer', 'default' => 10],
     ];
 
-    /** @var \Ibexa\Core\QueryType\QueryTypeRegistry */
-    private $queryTypeRegistry;
+    private QueryTypeRegistry $queryTypeRegistry;
 
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
-    /** @var string */
-    private $identifier;
+    private string $identifier;
 
     public function __construct(QueryTypeRegistry $queryTypeRegistry, ContentTypeService $contentTypeService, string $identifier)
     {

--- a/src/lib/GraphQL/ContentQueryFieldDefinitionMapper.php
+++ b/src/lib/GraphQL/ContentQueryFieldDefinitionMapper.php
@@ -15,14 +15,11 @@ use Ibexa\GraphQL\Schema\Domain\Content\NameHelper;
 
 final class ContentQueryFieldDefinitionMapper extends DecoratingFieldDefinitionMapper implements FieldDefinitionMapper
 {
-    /** @var \Ibexa\GraphQL\Schema\Domain\Content\NameHelper */
-    private $nameHelper;
+    private NameHelper $nameHelper;
 
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
-    /** @var string */
-    private $fieldTypeIdentifier;
+    private string $fieldTypeIdentifier;
 
     public function __construct(
         FieldDefinitionMapper $innerMapper,

--- a/src/lib/GraphQL/QueryFieldResolver.php
+++ b/src/lib/GraphQL/QueryFieldResolver.php
@@ -15,8 +15,7 @@ use Overblog\GraphQLBundle\Relay\Connection\Paginator;
 
 final class QueryFieldResolver
 {
-    /** @var \Ibexa\Contracts\FieldTypeQuery\QueryFieldServiceInterface */
-    private $queryFieldService;
+    private QueryFieldServiceInterface $queryFieldService;
 
     public function __construct(QueryFieldServiceInterface $queryFieldService)
     {

--- a/src/lib/QueryFieldService.php
+++ b/src/lib/QueryFieldService.php
@@ -26,14 +26,11 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
  */
 final class QueryFieldService implements QueryFieldServiceInterface, QueryFieldLocationService
 {
-    /** @var \Ibexa\Core\QueryType\QueryTypeRegistry */
-    private $queryTypeRegistry;
+    private QueryTypeRegistry $queryTypeRegistry;
 
-    /** @var \Ibexa\Contracts\Core\Repository\SearchService */
-    private $searchService;
+    private SearchService $searchService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
     public function __construct(
         SearchService $searchService,
@@ -146,7 +143,7 @@ final class QueryFieldService implements QueryFieldServiceInterface, QueryFieldL
     /**
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentException if $expression is not an expression.
      */
-    private function resolveExpression(string $expression, array $variables)
+    private function resolveExpression(string $expression, array $variables): mixed
     {
         if (!$this->isExpression($expression)) {
             throw new InvalidArgumentException('expression', 'is not an expression');


### PR DESCRIPTION
> [!CAUTION]
> These changes are volatile and - in some repositories - extensive, so they need to be carefully reviewed before merging.

| :ticket: Issue | IBX-9727 |
|----------------|-----------|

#### Description:

Added missing strict type hints using `\Rector\Set\ValueObject\SetList::TYPE_DECLARATION` set.
Additionally FQCNs have been imported for every affected file using PHP CS Fixer, in some cases they might override unrelated lines.

PHPStan bump is required due to requirements of Ibexa Rector and Rector itself.

#### For QA:

Regression tests.
