### PR TITLE
IBX-10228: Bump symfony/* requirement to ^7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
         "ibexa/rector": "~5.0.x-dev",
         "ibexa/rest": "~5.0.x-dev",
         "psr/log": "^3.0",
-        "symfony/dependency-injection": "^7.2",
-        "symfony/event-dispatcher": "^7.2",
-        "symfony/expression-language": "^7.2",
-        "symfony/framework-bundle": "^7.2",
-        "symfony/http-kernel": "^7.2",
-        "symfony/translation": "^7.2",
-        "symfony/yaml": "^7.2"
+        "symfony/dependency-injection": "^7.3",
+        "symfony/event-dispatcher": "^7.3",
+        "symfony/expression-language": "^7.3",
+        "symfony/framework-bundle": "^7.3",
+        "symfony/http-kernel": "^7.3",
+        "symfony/translation": "^7.3",
+        "symfony/yaml": "^7.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| :ticket: Issue | IBX-10228    |
|----------------|--------------|

#### Description:
This PR updates all symfony/* dependencies to ^7.3.

#### For QA:
N/A

#### Documentation:
N/A

