### PR TITLE
[UI][i18n] Extracted missing translations

### DIFF
--- a/src/bundle/Resources/translations/ibexa_fielddefinition.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_fielddefinition.en.xliff
@@ -6,12 +6,12 @@
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
     </header>
     <body>
-      <trans-unit id="63bb25b1f9154e4a451f0940afacd58edd948f45" resname="ibexa_content_query.no_defined_query_types">
+      <trans-unit id="04407ee30db18102d956f89891fbad32e28348e2" resname="ibexa_content_query.no_defined_query_types">
         <source>There are no query types defined</source>
         <target state="new">There are no query types defined</target>
         <note>key: ibexa_content_query.no_defined_query_types</note>
       </trans-unit>
-      <trans-unit id="95e9fc9f8e314bbd35a18372cd7888be0a1ec1e0" resname="ibexa_content_query.query_type.label">
+      <trans-unit id="566e6640662376d19eead76449d5c32ed517bc9f" resname="ibexa_content_query.query_type.label">
         <source>Query type:</source>
         <target state="new">Query type:</target>
         <note>key: ibexa_content_query.query_type.label</note>

--- a/src/bundle/Resources/translations/ibexa_fieldtypes.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_fieldtypes.en.xliff
@@ -6,7 +6,7 @@
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
     </header>
     <body>
-      <trans-unit id="c4d6ec2588a701ed1c113080b07918e3452b628b" resname="ibexa_content_query.name">
+      <trans-unit id="ada4ffa165648e9fce217f3394f97c67496f6f1b" resname="ibexa_content_query.name">
         <source>Content query</source>
         <target state="new">Content query</target>
         <note>key: ibexa_content_query.name</note>

--- a/src/bundle/Resources/translations/ibexa_repository_exceptions.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_repository_exceptions.en.xliff
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="726a8ce42306cda8f57496e18fc6573e3862f733" resname="EnablePagination is not a boolean">
+        <source>EnablePagination is not a boolean</source>
+        <target state="new">EnablePagination is not a boolean</target>
+        <note>key: EnablePagination is not a boolean</note>
+      </trans-unit>
+      <trans-unit id="1f11aa1725d4aa134e66f6851c94699f4bb56709" resname="ItemsPerPage is not an integer">
+        <source>ItemsPerPage is not an integer</source>
+        <target state="new">ItemsPerPage is not an integer</target>
+        <note>key: ItemsPerPage is not an integer</note>
+      </trans-unit>
+      <trans-unit id="dffaa194650dd1d72e5ec0056218716f9e0c80ff" resname="Parameters is not a valid YAML string">
+        <source>Parameters is not a valid YAML string</source>
+        <target state="new">Parameters is not a valid YAML string</target>
+        <note>key: Parameters is not a valid YAML string</note>
+      </trans-unit>
+      <trans-unit id="0cc105a5573b8c33c95c0d66497ed16b767b92ab" resname="The selected query type does not exist">
+        <source>The selected query type does not exist</source>
+        <target state="new">The selected query type does not exist</target>
+        <note>key: The selected query type does not exist</note>
+      </trans-unit>
+      <trans-unit id="7ebbf8332b91286f9a35c61e3054747e96c37fc4" resname="The selected returned type could not be loaded">
+        <source>The selected returned type could not be loaded</source>
+        <target state="new">The selected returned type could not be loaded</target>
+        <note>key: The selected returned type could not be loaded</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|

#### Description:

Extracted missing translations using our internal pre-release check tool. These changes are probably due to ibexa/core#590.

There's no PHPUnit nor integration test layer here, so adding `TranslationTest` is not straightforward ATM.