### PR TITLE
IBX-11832: Let Ibexa DXP support psr/log at least version 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/http-kernel": "^5.0",
         "symfony/translation": "^5.0",
         "symfony/yaml": "^5.0",
-        "psr/log": "^1.1"
+        "psr/log": "^1.1 || ^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| :ticket: Issue | IBX-11832 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/elasticsearch/pull/78
- https://github.com/ibexa/corporate-account-commerce-bridge/pull/23

#### Description:
Ibexa DXP 4.6 currently depend in psr/log ^1.1. However, that version is old and there are now a few 3rd party bundles that requires v2.0 or even 3.0. 
Therefore, Ibexa DXP 4.6 or later should support at least 2.0 ( in addition to 1.1), Ibexa DXP 5.0 already supports 3.0

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
